### PR TITLE
fixed the decoder sequence for string slice

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -149,7 +149,7 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart,
 				if d.zeroEmpty {
 					items = append(items, reflect.Zero(elemT))
 				}
-			} else if item := conv(value); item.IsValid() {
+			} else if item := conv(value); item.IsValid() && elemT.Kind() != reflect.String {
 				if isPtrElem {
 					ptr := reflect.New(elemT)
 					ptr.Elem().Set(item)


### PR DESCRIPTION
the decoder sequence will make []string always be passed into the first element.
added condition check for using converter to directly parse value.